### PR TITLE
Eq instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,13 @@ dist: trusty
 sudo: required
 node_js: stable
 install:
-  - npm install -g bower
+  - npm install -g bower pulp purescript
   - npm install
   - bower install
   - pulp build
 script:
   - npm run -s build
+  - pulp test
 after_success:
 - >-
   test $TRAVIS_TAG &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ install:
   - npm install -g bower pulp purescript
   - npm install
   - bower install
-  - pulp build
 script:
-  - npm run -s build
   - pulp test
 after_success:
 - >-

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ install:
   - npm install -g bower
   - npm install
   - bower install
+  - pulp build
 script:
   - npm run -s build
 after_success:

--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,6 @@
   },
   "devDependencies": {
     "purescript-assert": "^4.0.0",
-    "purescript-effect": "^2.0.0",
-    "purescript-console": "^4.2.0"
+    "purescript-effect": "^2.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -18,5 +18,13 @@
     "bower.json",
     "gulpfile.js",
     "package.json"
-  ]
+  ],
+  "dependencies": {
+    "purescript-prelude": "^4.1.0"
+  },
+  "devDependencies": {
+    "purescript-assert": "^4.0.0",
+    "purescript-effect": "^2.0.0",
+    "purescript-console": "^4.2.0"
+  }
 }

--- a/src/Data/ArrayBuffer/Types.js
+++ b/src/Data/ArrayBuffer/Types.js
@@ -1,0 +1,36 @@
+
+exports.dataViewEquals = function(dataView1) {
+  return function(dataView2) {
+    if(dataView1 === dataView2){ return true; }
+    if(dataView1.byteLength !== dataView2.byteLength) { return false; }
+    
+    for(var i = 0; i < dataView1.byteLength; i++){
+      if(dataView1.getUint8(i) !== dataView2.getUint8(i)) { return false; }
+    }
+    return true;
+  };
+};
+
+exports.arrayBufferEquals = function(buffer1) {
+  return function(buffer2) {
+    if(buffer1 === buffer2){ return true; }
+    // as of the latest versions of v8, it is supposedly faster to compare DataViews
+    // https://v8.dev/blog/dataview
+    return exports.dataViewEquals(new DataView(buffer1))(new DataView(buffer2));
+  };
+};
+
+exports.typedArrayEquals = function(array1){
+  return function(array2){
+    if(array1 === array2){ return true; }
+    if(array1.byteLength !== array2.byteLength) { return false; }
+    return array1.every(function(value, i){ 
+      return value == array2[i];
+    });
+  };
+};
+
+
+
+
+

--- a/src/Data/ArrayBuffer/Types.purs
+++ b/src/Data/ArrayBuffer/Types.purs
@@ -1,10 +1,43 @@
-module Data.ArrayBuffer.Types where
+module Data.ArrayBuffer.Types (
+  ArrayBuffer
+, DataView
+, ArrayView
+, ByteOffset
+, ByteLength
+, kind ArrayViewType
+, Int8
+, Int16
+, Int32
+, Uint8
+, Uint16
+, Uint32
+, Uint8Clamped
+, Float32
+, Float64
+, Int8Array
+, Int16Array
+, Int32Array
+, Uint8Array
+, Uint16Array
+, Uint32Array
+, Uint8ClampedArray
+, Float32Array
+, Float64Array
+)
+
+where
+
+import Prelude
 
 -- | Represents a JS ArrayBuffer object
 foreign import data ArrayBuffer :: Type
 
+instance eqArrayBuffer :: Eq ArrayBuffer where eq = arrayBufferEquals
+
 -- | Represents a JS DataView on an ArrayBuffer (a slice into the ArrayBuffer)
 foreign import data DataView :: Type
+
+instance eqDataView :: Eq DataView where eq = dataViewEquals
 
 -- | The unifying representation for the different typed arrays
 foreign import data ArrayView :: ArrayViewType -> Type
@@ -36,3 +69,18 @@ type Uint32Array = ArrayView Uint32
 type Uint8ClampedArray = ArrayView Uint8Clamped
 type Float32Array = ArrayView Float32
 type Float64Array = ArrayView Float64
+
+instance eqInt8Array :: Eq (ArrayView Int8) where eq = typedArrayEquals
+instance eqInt16Array :: Eq (ArrayView Int16) where eq = typedArrayEquals
+instance eqInt32Array :: Eq (ArrayView Int32) where eq = typedArrayEquals
+instance eqUint8Array :: Eq (ArrayView Uint8) where eq = typedArrayEquals
+instance eqUint16Array :: Eq (ArrayView Uint16) where eq = typedArrayEquals
+instance eqUint32Array :: Eq (ArrayView Uint32) where eq = typedArrayEquals
+instance eqUint8ClampedArray :: Eq (ArrayView Uint8Clamped) where eq = typedArrayEquals
+instance eqFloat32Array :: Eq (ArrayView Float32) where eq = typedArrayEquals
+instance eqFloat64Array :: Eq (ArrayView Float64) where eq = typedArrayEquals
+
+
+foreign import arrayBufferEquals :: ArrayBuffer -> ArrayBuffer -> Boolean
+foreign import dataViewEquals :: DataView -> DataView -> Boolean
+foreign import typedArrayEquals :: ∀ a. ArrayView a -> ArrayView a -> Boolean

--- a/test/Main.js
+++ b/test/Main.js
@@ -1,0 +1,60 @@
+
+
+
+// These are from
+// https://developers.google.com/web/updates/2012/06/How-to-convert-ArrayBuffer-to-and-from-String
+
+exports.bufferToString = function(buffer) {
+  return String.fromCharCode.apply(null, new Uint16Array(buffer));
+}
+
+exports.stringToArrayBuffer = function(str) {
+  var buffer = new ArrayBuffer(str.length*2); // 2 bytes for each char
+  var bufferView = new Uint16Array(buffer);
+  for (var i = 0, length =str.length; i < length; i++) {
+    bufferView[i] = str.charCodeAt(i);
+  }
+  return buffer;
+}
+
+exports.bufferToDataView = function(buffer){
+  return new DataView(buffer);
+}
+
+exports.int8Array = function(array){
+  return Int8Array.from(array);
+};
+
+exports.uint8Array = function(array){
+  return Uint8Array.from(array);
+};
+
+exports.uint8ClampedArray = function(array){
+  return Uint8ClampedArray.from(array);
+};
+
+exports.int16Array = function(array){
+  return Int16Array.from(array);
+};
+
+exports.uint16Array = function(array){
+  return Uint16Array.from(array);
+};
+
+exports.int32Array = function(array){
+  return Int32Array.from(array);
+};
+
+exports.uint32Array = function(array){
+  return Uint32Array.from(array);
+};
+
+exports.float32Array = function(array){
+  return Float32Array.from(array);
+};
+
+exports.float64Array = function(array){
+  return Float64Array.from(array);
+};
+
+

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,0 +1,82 @@
+module Test.Main where
+
+import Prelude
+
+import Data.ArrayBuffer.Types (ArrayBuffer, DataView, Float32Array, Float64Array, Int16Array, Int32Array, Int8Array, Uint16Array, Uint32Array, Uint8Array)
+import Effect (Effect)
+import Test.Assert (assert)
+
+main :: Effect Unit
+main = do
+  
+  let hello1 = stringToArrayBuffer "Hello"
+  let hello2 = stringToArrayBuffer "Hello"
+
+  let goodbye = stringToArrayBuffer "Goodbye"
+
+
+  assert ((stringToArrayBuffer mempty) == (stringToArrayBuffer mempty))
+  assert ((bufferToDataView (stringToArrayBuffer mempty)) == (bufferToDataView (stringToArrayBuffer mempty)))
+
+  assert (hello1 == hello2) 
+  assert (hello1 == hello1) 
+  assert (hello1 /= goodbye) 
+
+  assert ((bufferToDataView hello1) == (bufferToDataView hello2))
+  assert ((bufferToDataView hello1) == (bufferToDataView hello1))
+  assert ((bufferToDataView hello1) /= (bufferToDataView goodbye))
+
+  assert((int8Array mempty) == (int8Array mempty))
+  assert((int8Array [1,2,3]) == (int8Array [1,2,3]))
+  assert((int8Array [1,2,3]) /= (int8Array [4,5,6]))
+
+  assert((uint8Array mempty) == (uint8Array mempty))
+  assert((uint8Array [1,2,3]) == (uint8Array [1,2,3]))
+  assert((uint8Array [1,2,3]) /= (uint8Array [4,5,6]))
+
+  assert((uint8ClampedArray mempty) == (uint8ClampedArray mempty))
+  assert((uint8ClampedArray [1,2,3]) == (uint8ClampedArray [1,2,3]))
+  assert((uint8ClampedArray [1,2,3]) /= (uint8ClampedArray [4,5,6]))
+
+
+  assert((int16Array mempty) == (int16Array mempty))
+  assert((int16Array [1,2,3]) == (int16Array [1,2,3]))
+  assert((int16Array [1,2,3]) /= (int16Array [4,5,6]))
+
+  assert((uint16Array mempty) == (uint16Array mempty))
+  assert((uint16Array [1,2,3]) == (uint16Array [1,2,3]))
+  assert((uint16Array [1,2,3]) /= (uint16Array [4,5,6]))
+
+  assert((int32Array mempty) == (int32Array mempty))
+  assert((int32Array [1,2,3]) == (int32Array [1,2,3]))
+  assert((int32Array [1,2,3]) /= (int32Array [4,5,6]))
+
+  assert((uint32Array mempty) == (uint32Array mempty))
+  assert((uint32Array [1,2,3]) == (uint32Array [1,2,3]))
+  assert((uint32Array [1,2,3]) /= (uint32Array [4,5,6]))
+
+  assert((float32Array mempty) == (float32Array mempty))
+  assert((float32Array [1.0,2.0,3.0]) == (float32Array [1.0,2.0,3.0]))
+  assert((float32Array [1.0,2.0,3.0]) /= (float32Array [4.0,5.0,6.0]))
+
+  assert((float64Array mempty) == (float64Array mempty))
+  assert((float64Array [1.0,2.0,3.0]) == (float64Array [1.0,2.0,3.0]))
+  assert((float64Array [1.0,2.0,3.0]) /= (float64Array [4.0,5.0,6.0]))
+
+
+
+foreign import bufferToString :: ArrayBuffer -> String
+foreign import stringToArrayBuffer :: String -> ArrayBuffer 
+foreign import bufferToDataView :: ArrayBuffer -> DataView
+foreign import int8Array :: Array Int -> Int8Array
+foreign import uint8Array :: Array Int -> Uint8Array
+foreign import uint8ClampedArray :: Array Int -> Uint8Array
+foreign import int16Array :: Array Int -> Int16Array
+foreign import uint16Array :: Array Int -> Uint16Array
+foreign import int32Array :: Array Int -> Int32Array
+foreign import uint32Array :: Array Int -> Uint32Array
+foreign import float32Array :: Array Number -> Float32Array
+foreign import float64Array :: Array Number -> Float64Array
+
+
+ 


### PR DESCRIPTION
## What does this pull request do?

This is related to issue #11 

This adds `Eq` instances for `ArrayBuffer`, `DataView`, and each of the `ArrayViewType` types (`Int8`, `Uint8`, etc.)

## Where should the reviewer start?

Look in `Types.purs`. I've added a couple of foreign functions, to test equality, so the types are now all explicitly exported from the module. Then I'd look in `Types.js` at the JS code that does the equality comparison. I've opted in the case for testing equality on `ArrayBuffer`s to use `DataView`s behind the scenes since new versions of v8 suggest its more performant -- there is a comment in the JS code.

## How should this be manually tested?

In addition to the tests I've added, you could pull up a reply with this module and `purescript-arraybuffers` and test that equality works. I'll be making a PR on that repo once this is accepted.

## Other Notes:

Nothing much needs to be updated.
