### PR TITLE
Fix changelog for 3.0.1 release; add 3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Bugfixes:
 
 Other improvements:
 
-## [v3.0.1](https://github.com/purescript-contrib/purescript-arraybuffer-types/releases/tag/v3.0.1) - 2022-04-27
+## [v3.0.2](https://github.com/purescript-contrib/purescript-arraybuffer-types/releases/tag/v3.0.2) - 2022-04-27
 
 Breaking changes:
 
@@ -23,6 +23,8 @@ Bugfixes:
 Other improvements:
 - Miscellaneous CI updates (#26 by @JordanMartinez)
 - Added `purs-tidy` formatter (#25 by @thomashoneyman)
+
+## [v3.0.1](https://github.com/purescript-contrib/purescript-arraybuffer-types/releases/tag/v3.0.1) - 2021-07-21
 
 ## [v3.0.0](https://github.com/purescript-contrib/purescript-arraybuffer-types/releases/tag/v3.0.0) - 2021-02-26
 


### PR DESCRIPTION
**Description of the change**

A `3.0.1` tag was made, so when the `3.0.1` GH release was made for #27, the old tag was used rather than the current point of `main`. This updates the changelog and preps a `3.0.2` release.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [ ] Added a test for the contribution (if applicable)
